### PR TITLE
Switch to iohk-nix as a flake and new overlay setup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,23 @@
         "type": "github"
       }
     },
+    "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656163412,
+        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      }
+    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -537,13 +554,20 @@
       }
     },
     "iohk-nix": {
-      "flake": false,
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
       "locked": {
-        "lastModified": 1684223806,
-        "narHash": "sha256-IyLoP+zhuyygLtr83XXsrvKyqqLQ8FHXTiySFf4FJOI=",
+        "lastModified": 1685727458,
+        "narHash": "sha256-c/pkFYCfzpRb6W2OOKE+EOzOlcw+96vwJGGg8Ir9Qfk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86421fdd89b3af43fa716ccd07638f96c6ecd1e4",
+        "rev": "02f42375ee5c2bab1640f14c6389b7e91bbfec8b",
         "type": "github"
       },
       "original": {
@@ -1074,6 +1098,40 @@
         "nosys": "nosys_2",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
       }
     },
     "sphinxcontrib-haddock": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
 
     iohk-nix = {
       url = "github:input-output-hk/iohk-nix";
-      flake = false;
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     sphinxcontrib-haddock = {

--- a/src/bootstrap/pkgs.nix
+++ b/src/bootstrap/pkgs.nix
@@ -3,16 +3,17 @@
 let
   libsodium-vrf-overlay = import ./libsodium-vrf-overlay.nix;
   R-overlay = import ./R-overlay.nix;
-  iohk-nix = import iogx-inputs.iohk-nix { };
+  inherit (iogx-inputs) iohk-nix;
 in
 import iogx-inputs.nixpkgs {
   inherit system;
   config = iogx-inputs.haskell-nix.config;
   overlays =
-    iohk-nix.overlays.iohkNix ++
-    iohk-nix.overlays.haskell-nix-extra ++
     [
+      iohk-nix.overlays.crypto
       iogx-inputs.haskell-nix.overlay
+      iohk-nix.overlays.haskell-nix-crypto
+      iohk-nix.overlays.haskell-nix-extra
       libsodium-vrf-overlay
       R-overlay
     ];


### PR DESCRIPTION
Testing this locally, but I think it's required to get proper cross-compilation for Haskell packages depending on the crypto overlay.

Note that due to https://github.com/NixOS/nix/issues/8511 it seems like upgrading to this version of iogx will require removing iogx from downstream flakes, locking, then re-adding it and locking again.