### PR TITLE
Fix README.md: api ref link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ nix flake init --template github:input-output-hk/iogx#vanilla
 
 These will generates a `flake.nix` and a `nix` folder in your repository root.
 
-You may now move on to the [API Reference](./doc/options.md).
+You may now move on to the [API Reference](./doc/api.md).
 
 # 2. Features
 


### PR DESCRIPTION

If this was the intention (`api.md` instead if `options.md`)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Documentation: Updated a link in the README file to direct users to the correct API documentation. This change ensures users are guided to the most relevant and up-to-date information, enhancing the usability of our documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->