### PR TITLE
Add option to exclude profiled builds from hydra

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -865,7 +865,7 @@ in
 
 When set to `true` then [`mkHaskellProject.<out>.flake`](#mkhaskellprojectoutflake) will include:
 ```nix 
-hydraJobs.mingwW66 = project.cross.mingwW64
+hydraJobs.mingwW66 = project.cross.mingwW64.hydraJobs
 ```
 
 This is just a convenience option, you can always reference the jobs directly:
@@ -883,6 +883,60 @@ in
   }
 ]
 ```
+
+
+---
+
+### `mkHaskellProject.<in>.includeProfiledHydraJobs`
+
+**Type**: boolean
+
+**Default**: `false`
+
+
+**Example**: 
+```nix
+# outputs.nix 
+{ repoRoot, inputs, pkgs, lib, system }:
+let 
+  project = lib.iogx.mkHaskellProject {
+    includeProfiledHydraJobs = true;
+  };
+in 
+[
+  (
+    project.flake 
+    # ^^^^^ Includes: hydraJobs.profiled = project.variants.profiled.hydraJobs;
+  )
+]
+```
+
+```
+
+
+When set to `true` then [`mkHaskellProject.<out>.flake`](#mkhaskellprojectoutflake) will include:
+```nix 
+hydraJobs.profiled = project.variants.profiled.hydraJobs;
+```
+
+This is just a convenience option, you can always reference the jobs directly:
+```nix
+# outputs.nix 
+{ repoRoot, inputs, pkgs, lib, system }:
+let 
+  project = lib.iogx.mkHaskellProject {
+    includeProfiledHydraJobs = false;
+  };
+in 
+[
+  {
+    hydraJobs.profiled = project.variants.profiled.hydraJobs;
+  }
+]
+```
+
+This option assumes that you have defined a flake variant called `profiled` in your
+haskell.nix `cabalProject` (see the example above).
 
 
 ---

--- a/flake.lock
+++ b/flake.lock
@@ -676,6 +676,22 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -703,22 +719,6 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-with-working-prefetch-npm-deps": {
-      "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
         "type": "github"
       }
     },
@@ -761,7 +761,7 @@
         "flake-utils": "flake-utils_3",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1696846637,
@@ -789,7 +789,7 @@
           "haskell-nix",
           "nixpkgs"
         ],
-        "nixpkgs-with-working-prefetch-npm-deps": "nixpkgs-with-working-prefetch-npm-deps",
+        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       }

--- a/src/core/mkHaskellProject.nix
+++ b/src/core/mkHaskellProject.nix
@@ -140,7 +140,7 @@ let
         (system == "x86_64-linux" && haskellProject.includeMingwW64HydraJobs)
         { mingwW64 = project.cross.mingwW64.hydraJobs; };
 
-      variants-job =
+      variants-jobs =
         let all = utils.mapAttrValues (project: project.hydraJobs) project.variants;
         in if haskellProject.includeProfiledHydraJobs then all else removeAttrs all [ "profiled" ];
 

--- a/src/core/mkHaskellProject.nix
+++ b/src/core/mkHaskellProject.nix
@@ -128,6 +128,42 @@ let
     };
 
 
+  mkDefaultFlake = project:
+    let
+      extra-packages = {
+        combined-haddock = project.combined-haddock;
+        read-the-docs-site = project.read-the-docs-site;
+        pre-commit-check = project.pre-commit-check;
+      };
+
+      mingwW64-jobs = lib.optionalAttrs
+        (system == "x86_64-linux" && haskellProject.includeMingwW64HydraJobs)
+        { mingwW64 = project.cross.mingwW64.hydraJobs; };
+
+      variants-job =
+        let all = utils.mapAttrValues (project: project.hydraJobs) project.variants;
+        in if haskellProject.includeProfiledHydraJobs then all else removeAttrs all [ "profiled" ];
+
+      required-job = { required = repoRoot.src.core.mkHydraRequiredJob { }; };
+    in
+    {
+      devShell = project.devShell;
+      devShells = project.devShells;
+      apps = project.apps;
+      checks = project.checks;
+      cabalProject = project.cabalProject;
+
+      packages = project.packages // extra-packages;
+
+      hydraJobs =
+        required-job //
+        project.hydraJobs //
+        extra-packages //
+        variants-jobs //
+        mingwW64-jobs;
+    };
+
+
   iogx-project =
     let
       base = haskellProject.cabalProject;
@@ -143,25 +179,7 @@ let
         (mkProjectVariant base) //
         { variants = utils.mapAttrValues mkProjectVariant base.projectVariants; };
 
-      extra-packages = {
-        inherit (project) combined-haddock read-the-docs-site pre-commit-check;
-      };
-
-      flake = {
-        inherit (project) devShell devShells apps checks cabalProject;
-        _iogx = project;
-        packages = project.packages // extra-packages;
-        hydraJobs = lib.optionalAttrs (system != "aarch64-linux") (
-          # TODO profiled
-          project.hydraJobs //
-          extra-packages //
-          utils.mapAttrValues (project: project.hydraJobs) project.variants //
-          { required = repoRoot.src.core.mkHydraRequiredJob { }; } //
-          lib.optionalAttrs
-            (system == "x86_64-linux" && haskellProject.includeMingwW64HydraJobs)
-            { mingwW64 = project.cross.mingwW64.hydraJobs; }
-        );
-      };
+      flake = mkDefaultFlake project;
     in
     project // { inherit flake; };
 

--- a/src/options/mkHaskellProject.nix
+++ b/src/options/mkHaskellProject.nix
@@ -180,9 +180,55 @@ let
         '';
       };
 
+      includeProfiledHydraJobs = l.mkOption {
+        type = l.types.bool;
+        default = false;
+        example = l.literalExpression ''
+          # outputs.nix 
+          { repoRoot, inputs, pkgs, lib, system }:
+          let 
+            project = lib.iogx.mkHaskellProject {
+              includeProfiledHydraJobs = true;
+            };
+          in 
+          [
+            (
+              project.flake 
+              # ^^^^^ Includes: hydraJobs.profiled = project.variants.profiled.hydraJobs;
+            )
+          ]
+          ```
+        '';
+        description = ''
+          When set to `true` then ${link "mkHaskellProject.<out>.flake"} will include:
+          ```nix 
+          hydraJobs.profiled = project.variants.profiled.hydraJobs;
+          ```
+
+          This is just a convenience option, you can always reference the jobs directly:
+          ```nix
+          # outputs.nix 
+          { repoRoot, inputs, pkgs, lib, system }:
+          let 
+            project = lib.iogx.mkHaskellProject {
+              includeProfiledHydraJobs = false;
+            };
+          in 
+          [
+            {
+              hydraJobs.profiled = project.variants.profiled.hydraJobs;
+            }
+          ]
+          ```
+
+          This option assumes that you have defined a flake variant called `profiled` in your
+          haskell.nix `cabalProject` (see the example above).
+        '';
+      };
+
       includeMingwW64HydraJobs = l.mkOption {
         type = l.types.bool;
-        default = false; 
+        default = false;
         example = l.literalExpression ''
           # outputs.nix 
           { repoRoot, inputs, pkgs, lib, system }:
@@ -202,7 +248,7 @@ let
         description = ''
           When set to `true` then ${link "mkHaskellProject.<out>.flake"} will include:
           ```nix 
-          hydraJobs.mingwW66 = project.cross.mingwW64
+          hydraJobs.mingwW66 = project.cross.mingwW64.hydraJobs
           ```
 
           This is just a convenience option, you can always reference the jobs directly:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Added `mkDefaultFlake` function to generate a default flake configuration, simplifying the setup process.
- Introduced `includeProfiledHydraJobs` and `includeMingwW64HydraJobs` options in Nix expressions, providing convenience for including specific Hydra jobs.

Documentation:
- Updated API documentation with new options `includeProfiledHydraJobs` and `readTheDocs` for `mkHaskellProject`, enhancing clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->