### PR TITLE
 Replace vars names containing double quotes 

### DIFF
--- a/src/core/mkShellWith.nix
+++ b/src/core/mkShellWith.nix
@@ -1,6 +1,6 @@
 { repoRoot, iogx-inputs, user-inputs, pkgs, lib, system, ... }:
 
-shell'':
+shellCfg:
 # The shell config provided by the user (mkShell-IN).
 
 extra-shell-profiles:
@@ -14,7 +14,7 @@ let
   evaluated-shell-module = lib.evalModules {
     modules = [{
       options = lib.iogx.options;
-      config."mkShell.<in>" = shell'';
+      config."mkShell.<in>" = shellCfg;
     }];
   };
 

--- a/src/lib/utils.nix
+++ b/src/lib/utils.nix
@@ -10,9 +10,9 @@ let
     headerToLocalMarkDownLink = tag: name:
       let
         name' = l.replaceStrings [ "<" ">" "." " " ] [ "" "" "" "-" ] name;
-        name'' = l.strings.toLower name';
+        nameLower = l.strings.toLower name';
       in
-      "[`${tag}`](#${name''})";
+      "[`${tag}`](#${nameLower})";
 
 
     composeManyLeft = y: xs: l.foldl' (x: f: f x) xs y;


### PR DESCRIPTION
This fixes a parsing issues in some editors as double quotes is used for multi line strings in nix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal naming conventions for shell configuration, enhancing readability and maintainability without changing user-facing functionality.
  - Updated utility function for better clarity in code, with no impact on its behavior or output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->