### PR TITLE
Allow any value for `haskellCompilerVersion`

### DIFF
--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -31,24 +31,28 @@ let
         cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
       }
     else
-      lib.iogx.utils.iogxThrow "\nUnsupported GHC version: ${ghc}";
+      {
+        rev = "2.4.0.0";
+        sha256 = "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=";
+        cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
+      }
 
-in
+    in
 
-pkgs.haskell-nix.cabalProject' {
+    pkgs.haskell-nix.cabalProject' {
 
-  # See https://github.com/haskell/haskell-language-server/issues/411.
-  # We want to use stylish-haskell, hlint, and implicit-hie as standalone tools
-  # *and* through HLS. But we need to have consistent versions in both cases,
-  # otherwise e.g. you could format the code in HLS and then have the CI
-  # complain that it's wrong
-  #
-  # The solution we use here is to:
-  # a) Where we care (mostly just formatters), constrain the versions of
-  #    tools which HLS uses explicitly
-  # b) Pull out the tools themselves from the HLS project so we can use
-  #    them elsewhere
-  cabalProjectLocal = config.cabalProjectLocal or "";
+    # See https://github.com/haskell/haskell-language-server/issues/411.
+    # We want to use stylish-haskell, hlint, and implicit-hie as standalone tools
+    # *and* through HLS. But we need to have consistent versions in both cases,
+    # otherwise e.g. you could format the code in HLS and then have the CI
+    # complain that it's wrong
+    #
+    # The solution we use here is to:
+    # a) Where we care (mostly just formatters), constrain the versions of
+    #    tools which HLS uses explicitly
+    # b) Pull out the tools themselves from the HLS project so we can use
+    #    them elsewhere
+    cabalProjectLocal = config.cabalProjectLocal or "";
 
   configureArgs = config.configureArgs or "";
 
@@ -70,4 +74,4 @@ pkgs.haskell-nix.cabalProject' {
 
     dontStrip = false;
   }];
-}
+  }

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -35,24 +35,24 @@ let
         rev = "2.4.0.0";
         sha256 = "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=";
         cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
-      }
+      };
 
-    in
+in
 
-    pkgs.haskell-nix.cabalProject' {
+pkgs.haskell-nix.cabalProject' {
 
-    # See https://github.com/haskell/haskell-language-server/issues/411.
-    # We want to use stylish-haskell, hlint, and implicit-hie as standalone tools
-    # *and* through HLS. But we need to have consistent versions in both cases,
-    # otherwise e.g. you could format the code in HLS and then have the CI
-    # complain that it's wrong
-    #
-    # The solution we use here is to:
-    # a) Where we care (mostly just formatters), constrain the versions of
-    #    tools which HLS uses explicitly
-    # b) Pull out the tools themselves from the HLS project so we can use
-    #    them elsewhere
-    cabalProjectLocal = config.cabalProjectLocal or "";
+  # See https://github.com/haskell/haskell-language-server/issues/411.
+  # We want to use stylish-haskell, hlint, and implicit-hie as standalone tools
+  # *and* through HLS. But we need to have consistent versions in both cases,
+  # otherwise e.g. you could format the code in HLS and then have the CI
+  # complain that it's wrong
+  #
+  # The solution we use here is to:
+  # a) Where we care (mostly just formatters), constrain the versions of
+  #    tools which HLS uses explicitly
+  # b) Pull out the tools themselves from the HLS project so we can use
+  #    them elsewhere
+  cabalProjectLocal = config.cabalProjectLocal or "";
 
   configureArgs = config.configureArgs or "";
 
@@ -74,4 +74,4 @@ let
 
     dontStrip = false;
   }];
-  }
+}

--- a/src/options/mkShell.nix
+++ b/src/options/mkShell.nix
@@ -97,25 +97,18 @@ let
     options = {
       haskellCompilerVersion = l.mkOption {
         default = null;
-        type = l.types.nullOr (l.types.enum [
-          "ghc810"
-          "ghc8107"
-          "ghc92"
-          "ghc927"
-          "ghc928"
-          "ghc96"
-          "ghc962"
-          "ghc981"
-        ]);
+        type = l.types.nullOr l.types.str;
         description = ''
           The haskell compiler version.
+          
+          Any value that is accepected by `haskell.nix:compiler-nix-name` is valid, e.g: `ghc8107`, `ghc92`, `ghc963`.
           
           This determines the version of other tools like `cabal-install` and `haskell-language-server`.
 
           If this option is unset of null, then no Haskell tools will be made available in the shell.
 
           However if you enable some Haskell-specific ${link "mkShell.<in>.preCommit"} hooks, then 
-          that Haskell tools will be installed automatically using `ghc8107` as the default compiler version.
+          that Haskell tool will be installed automatically using `ghc8107` as the default compiler version.
 
           When using ${link "mkHaskellProject.<in>.shellArgs"}, this option is automatically set to 
           the same value as the project's (or project variant's) `compiler-nix-name`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the Haskell project configuration to support a new module.
	- Enhanced flexibility in specifying Haskell compiler versions.

- **Documentation**
	- Improved option descriptions to clarify usage and effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->