### PR TITLE
Run `render-iogx-api-reference`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -3128,7 +3128,7 @@ If unset or `null`, [`mkShell.<in>.tools.haskellCompilerVersion`](#mkshellintool
 
 ### `mkShell.<in>.tools.haskellCompilerVersion`
 
-**Type**: null or one of "ghc810", "ghc8107", "ghc92", "ghc927", "ghc928", "ghc96", "ghc962", "ghc981"
+**Type**: null or string
 
 **Default**: `null`
 
@@ -3147,12 +3147,14 @@ lib.iogx.mkShell {
 
 The haskell compiler version.
 
+Any value that is accepected by `haskell.nix:compiler-nix-name` is valid, e.g: `ghc8107`, `ghc92`, `ghc963`.
+
 This determines the version of other tools like `cabal-install` and `haskell-language-server`.
 
 If this option is unset of null, then no Haskell tools will be made available in the shell.
 
 However if you enable some Haskell-specific [`mkShell.<in>.preCommit`](#mkshellinprecommit) hooks, then 
-that Haskell tools will be installed automatically using `ghc8107` as the default compiler version.
+that Haskell tool will be installed automatically using `ghc8107` as the default compiler version.
 
 When using [`mkHaskellProject.<in>.shellArgs`](#mkhaskellprojectinshellargs), this option is automatically set to 
 the same value as the project's (or project variant's) `compiler-nix-name`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated API documentation to reflect the expanded compatibility for the `haskellCompilerVersion` field, now accepting any string value as per `haskell.nix:compiler-nix-name`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->