### PR TITLE
Better support for ghc98

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,19 @@
     "hackage": {
       "flake": false,
       "locked": {
+<<<<<<< Updated upstream
         "lastModified": 1702513363,
         "narHash": "sha256-kloro9uEe8aYhPMoMjVNq2rfrXNgMOZhOPwVH5DH2K0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
         "rev": "a9d931d0398da67846fa257922a924829233cb91",
+=======
+        "lastModified": 1703636672,
+        "narHash": "sha256-QVADvglA1x9WpQFij73VvdvnqquCUCNBM0BOFHXQz0Y=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "6a9040a7f72c7e629b286a461cf856d987c163ba",
+>>>>>>> Stashed changes
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -318,19 +318,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-<<<<<<< Updated upstream
-        "lastModified": 1702513363,
-        "narHash": "sha256-kloro9uEe8aYhPMoMjVNq2rfrXNgMOZhOPwVH5DH2K0=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "a9d931d0398da67846fa257922a924829233cb91",
-=======
         "lastModified": 1703636672,
         "narHash": "sha256-QVADvglA1x9WpQFij73VvdvnqquCUCNBM0BOFHXQz0Y=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
         "rev": "6a9040a7f72c7e629b286a461cf856d987c163ba",
->>>>>>> Stashed changes
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1702500577,
-        "narHash": "sha256-gKzGdkTOWveP6ncpu61vUmLzF9idkNuYNlem8WtOY4Q=",
+        "lastModified": 1703398734,
+        "narHash": "sha256-DVaL6dBqgGOOjr3kyHi3NgtD4UrwTVsSMLkpUToyPt4=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "b04823d600fd69293bf8fcaff67a980197c59cd5",
+        "rev": "dbfa903050eb861fcbd0c22dd5a4746f68d6d42e",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1702515007,
-        "narHash": "sha256-qKHXQKP4vOP+aIjaMrBZ9qDWVrzz4AKgy3byIkZJOBE=",
+        "lastModified": 1703638209,
+        "narHash": "sha256-MeEwFKZGA+DEx54IE4JQQi5ss+kplyikHQFlc2pz3NM=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "24d57d2e7fcddebe6f2decfbda0149fcda042558",
+        "rev": "3e17b0afaa245a660e02af7323de96153124928b",
         "type": "github"
       },
       "original": {
@@ -453,16 +453,16 @@
     "hls-2.4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696939266,
-        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.4.0.0",
+        "ref": "2.4.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -516,11 +516,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1696445248,
-        "narHash": "sha256-2B/fqwyaRAaHVmkf15tKwkFbL5O46TmMw+Rc2viUPEY=",
+        "lastModified": 1702362799,
+        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "e32040e84180b3c27c0f13587025f6a17a4da520",
+        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1701981188,
-        "narHash": "sha256-oXFdqisYyJ77yDZ3OaAGp+GYUS6e3tWFuavl/AgBdRI=",
+        "lastModified": 1703410130,
+        "narHash": "sha256-qbJQ8DtdKzFK0fZck7kX64QWkS/3tKefxGjyI+SAQa4=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "3e84a0a7b94419846acd9c52c4c497c618b2cb7e",
+        "rev": "6aa8491e73843ac8bf714a3904a45900f356ea44",
         "type": "github"
       },
       "original": {
@@ -780,17 +780,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1701336116,
-        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -851,11 +851,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1696846637,
-        "narHash": "sha256-0hv4kbXxci2+pxhuXlVgftj/Jq79VSmtAyvfabCCtYk=",
+        "lastModified": 1703426812,
+        "narHash": "sha256-aODSOH8Og8ne4JylPJn+hZ6lyv6K7vE5jFo4KAGIebM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "42e1b6095ef80a51f79595d9951eb38e91c4e6ca",
+        "rev": "7f35ec30d16b38fe0eed8005933f418d1a4693ee",
         "type": "github"
       },
       "original": {
@@ -935,11 +935,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1702512570,
-        "narHash": "sha256-Kj55cSmbhahembr0TnzBCS3SeKMZSPzeX4I8H2CF9pg=",
+        "lastModified": 1703635755,
+        "narHash": "sha256-lLvI2HgVSYAPlsxF1zOb+VYBLc9pse0+W49ShuPi/jY=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "05cf45a817f18547191c02b0f9cd0d2a093355ff",
+        "rev": "ce032ad63ef03ace9f481c508b461743271dfa3e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1696842570,
-        "narHash": "sha256-DLtOawpMWt0L0LnandKtDJKSiCbSqhz2LTWofMw6sLw=",
+        "lastModified": 1700639964,
+        "narHash": "sha256-iQ48z5eqSHP8d7B8BBJtnXkVPIKPvdWc0GhIgy4j8cc=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "2acbea2f58966e84a77e854e4a980bbd2d501414",
+        "rev": "eaf713ef8029332b9e4e23685fa157f26086da8b",
         "type": "github"
       },
       "original": {
@@ -257,14 +257,14 @@
         "type": "github"
       }
     },
-    "ghc980": {
+    "ghc98X": {
       "flake": false,
       "locked": {
-        "lastModified": 1692910316,
-        "narHash": "sha256-Qv8I3GzzIIN32RTEKI38BW5nO1f7j6Xm+dDeDUyYZWo=",
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
         "ref": "ghc-9.8",
-        "rev": "249aa8193e4c5c1ee46ce29b39d2fffa57de7904",
-        "revCount": 61566,
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -279,11 +279,11 @@
     "ghc99": {
       "flake": false,
       "locked": {
-        "lastModified": 1695427505,
-        "narHash": "sha256-j0hXl6uEI+Uwf37z3WLuQZN4S0XqGtiepELv2Gl2aHU=",
+        "lastModified": 1697054644,
+        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
         "ref": "refs/heads/master",
-        "rev": "b8e4fe2318798185228fb5f8214ba2384ac95b4f",
-        "revCount": 61951,
+        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
+        "revCount": 62040,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -318,11 +318,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1696983806,
-        "narHash": "sha256-9GJ/pSU2/Fmlqtz6fJpom/aIeNDX1iLNTvrM52UFndA=",
+        "lastModified": 1700612632,
+        "narHash": "sha256-UzG6TDIano8KutKie9wI5yvvN3CfUfWOSBgDtuDa0L0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d927508b348a686b357cd90d30ad90d4b70f465f",
+        "rev": "2674c27b8de693e83776083ed5fdf95e54be6463",
         "type": "github"
       },
       "original": {
@@ -340,7 +340,7 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc980": "ghc980",
+        "ghc98X": "ghc98X",
         "ghc99": "ghc99",
         "hackage": [
           "hackage"
@@ -349,6 +349,7 @@
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -367,11 +368,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1696995756,
-        "narHash": "sha256-Te0lJDA3MfzWDlNPvZQ6ECjQ3miqcKbGv+wA9aFywVE=",
+        "lastModified": 1700638396,
+        "narHash": "sha256-vQy1p94QFz8Lo+x2zZLb2gmNGtm2CUWk9j/IkuETs1s=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2ebea581e35a3611a9da3ead59f2337c2347b0af",
+        "rev": "fc060cf2934f7f206a4340ef86f5764b2f95737d",
         "type": "github"
       },
       "original": {
@@ -444,6 +445,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696939266,
+        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -900,11 +918,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1696982937,
-        "narHash": "sha256-KASiTJAbIDfiMhHcoi2qtCYeTvRhZpR5PKzWQCteih4=",
+        "lastModified": 1700438989,
+        "narHash": "sha256-x+7Qtboko7ds8CU8pq2sIZiD45DauYoX9LxBfwQr/hs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "5531e02e80e9eeec3c817d24660e8e58e2f05703",
+        "rev": "9c2015334cc77837b8454b3b10ef4f711a256f6f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1700639964,
-        "narHash": "sha256-iQ48z5eqSHP8d7B8BBJtnXkVPIKPvdWc0GhIgy4j8cc=",
+        "lastModified": 1702500577,
+        "narHash": "sha256-gKzGdkTOWveP6ncpu61vUmLzF9idkNuYNlem8WtOY4Q=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "eaf713ef8029332b9e4e23685fa157f26086da8b",
+        "rev": "b04823d600fd69293bf8fcaff67a980197c59cd5",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
     "ghc99": {
       "flake": false,
       "locked": {
-        "lastModified": 1697054644,
-        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "lastModified": 1701580282,
+        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
         "ref": "refs/heads/master",
-        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
-        "revCount": 62040,
+        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
+        "revCount": 62197,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -318,11 +318,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1700612632,
-        "narHash": "sha256-UzG6TDIano8KutKie9wI5yvvN3CfUfWOSBgDtuDa0L0=",
+        "lastModified": 1702513363,
+        "narHash": "sha256-kloro9uEe8aYhPMoMjVNq2rfrXNgMOZhOPwVH5DH2K0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "2674c27b8de693e83776083ed5fdf95e54be6463",
+        "rev": "a9d931d0398da67846fa257922a924829233cb91",
         "type": "github"
       },
       "original": {
@@ -363,16 +363,17 @@
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1700638396,
-        "narHash": "sha256-vQy1p94QFz8Lo+x2zZLb2gmNGtm2CUWk9j/IkuETs1s=",
+        "lastModified": 1702515007,
+        "narHash": "sha256-qKHXQKP4vOP+aIjaMrBZ9qDWVrzz4AKgy3byIkZJOBE=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "fc060cf2934f7f206a4340ef86f5764b2f95737d",
+        "rev": "24d57d2e7fcddebe6f2decfbda0149fcda042558",
         "type": "github"
       },
       "original": {
@@ -699,16 +700,32 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1695416179,
-        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1701386440,
+        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -763,11 +780,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1701336116,
+        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
         "type": "github"
       },
       "original": {
@@ -918,11 +935,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1700438989,
-        "narHash": "sha256-x+7Qtboko7ds8CU8pq2sIZiD45DauYoX9LxBfwQr/hs=",
+        "lastModified": 1702512570,
+        "narHash": "sha256-Kj55cSmbhahembr0TnzBCS3SeKMZSPzeX4I8H2CF9pg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "9c2015334cc77837b8454b3b10ef4f711a256f6f",
+        "rev": "05cf45a817f18547191c02b0f9cd0d2a093355ff",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
         hydraJobs.devShells.ghc810 = mkDevShell lib "ghc810";
         hydraJobs.devShells.ghc92 = mkDevShell lib "ghc92";
         hydraJobs.devShells.ghc96 = mkDevShell lib "ghc96";
+        hydraJobs.devShells.ghc98 = mkDevShell lib "ghc98";
         hydraJobs.render-iogx-api-reference = repoRoot.src.core.mkRenderedIogxApiReference;
         hydraJobs.required = lib.iogx.mkHydraRequiredJob { };
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
 
   inputs = {
 
+
     haskell-nix = {
       url = "github:input-output-hk/haskell.nix";
       inputs.hackage.follows = "hackage";

--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,9 @@
         hydraJobs.render-iogx-api-reference = repoRoot.src.core.mkRenderedIogxApiReference;
         hydraJobs.required = lib.iogx.mkHydraRequiredJob { };
 
+        _test_cabal98 = repoRoot.src.ext.cabal-install "ghc98";
+        _test_hls98 = repoRoot.src.ext.haskell-language-server-project "ghc98";
+
         devShells.default = lib.iogx.mkShell {
           name = "iogx";
           packages = [

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,6 @@
         hydraJobs.render-iogx-api-reference = repoRoot.src.core.mkRenderedIogxApiReference;
         hydraJobs.required = lib.iogx.mkHydraRequiredJob { };
 
-        _test_cabal98 = repoRoot.src.ext.cabal-install "ghc98";
         _test_hls98 = repoRoot.src.ext.haskell-language-server-project "ghc98";
 
         devShells.default = lib.iogx.mkShell {

--- a/src/core/mkShellWith.nix
+++ b/src/core/mkShellWith.nix
@@ -50,8 +50,8 @@ let
 
 
   getHlsTool = name:
-    let hls = if lib.hasInfix ghc "ghc98" then hls96 else hls;
-    in hls.hsPkgs.${name}.components.exes.${name};
+    let hls' = if lib.hasInfix ghc "ghc98" then hls96 else hls;
+    in hls'.hsPkgs.${name}.components.exes.${name};
 
 
   default-tools = {

--- a/src/core/mkShellWith.nix
+++ b/src/core/mkShellWith.nix
@@ -43,9 +43,15 @@ let
 
 
   hls = repoRoot.src.ext.haskell-language-server-project ghc;
+  hls96 = repoRoot.src.ext.haskell-language-server-project "ghc96";
 
 
   purescript = pkgs.callPackage iogx-inputs.easy-purescript-nix { };
+
+
+  getHlsTool = name:
+    let hls = if lib.hasInfix ghc "ghc98" then hls96 else hls;
+    in hls.hsPkgs.${name}.components.exes.${name};
 
 
   default-tools = {
@@ -53,10 +59,10 @@ let
     haskell-language-server = hls.hsPkgs.haskell-language-server.components.exes.haskell-language-server;
     haskell-language-server-wrapper = hls.hsPkgs.haskell-language-server.components.exes.haskell-language-server-wrapper;
 
-    stylish-haskell = hls.hsPkgs.stylish-haskell.components.exes.stylish-haskell;
+    stylish-haskell = getHlsTool "stylish-haskell";
+    hlint = getHlsTool "hlint";
     cabal-fmt = repoRoot.src.ext.cabal-fmt;
     fourmolu = repoRoot.src.ext.fourmolu;
-    hlint = hls.hsPkgs.hlint.components.exes.hlint;
 
     shellcheck = pkgs.shellcheck;
     prettier = pkgs.nodePackages.prettier;

--- a/src/ext/cabal-install.nix
+++ b/src/ext/cabal-install.nix
@@ -4,13 +4,25 @@ ghc:
 
 let
 
+  config =
+    if lib.hasInfix "ghc98" ghc then
+      {
+        # TODO remove this hack when a new version of cabal (> 3.10.1.0) 
+        # is released which can be built with ghc98. 
+        compiler-nix-name = "ghc96";
+      }
+    else
+      {
+        compiler-nix-name = ghc;
+      };
+
   project = pkgs.haskell-nix.hackage-project {
 
     name = "cabal-install";
 
     version = "3.10.1.0";
 
-    compiler-nix-name = ghc;
+    compiler-nix-name = config.compiler-nix-name;
 
     # The test suite depends on a nonexistent package...
     configureArgs = "--disable-tests";

--- a/src/ext/cabal-install.nix
+++ b/src/ext/cabal-install.nix
@@ -7,22 +7,20 @@ let
   config =
     if lib.hasInfix "ghc98" ghc then
       {
-        # TODO remove this hack when a new version of cabal (> 3.10.1.0) 
-        # is released which can be built with ghc98. 
-        compiler-nix-name = "ghc96";
+        version = "3.10.2.1";
       }
     else
       {
-        compiler-nix-name = ghc;
+        version = "3.10.1.0";
       };
 
   project = pkgs.haskell-nix.hackage-project {
 
     name = "cabal-install";
 
-    version = "3.10.1.0";
+    version = config.version;
 
-    compiler-nix-name = config.compiler-nix-name;
+    compiler-nix-name = ghc;
 
     # The test suite depends on a nonexistent package...
     configureArgs = "--disable-tests";

--- a/src/ext/fourmolu.nix
+++ b/src/ext/fourmolu.nix
@@ -8,7 +8,7 @@ let
     name = "fourmolu";
     version = "0.13.0.0";
     compiler-nix-name = "ghc928";
-
+    index-state = "2023-10-11T00:00:00Z";
     # Otherwise it would use aeson-2.2.0.0 which no longer exports 
     # Data.Aeson.Internal, which in turn breask yaml-0.11.11.1
     cabalProjectLocal = '' 

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -24,13 +24,22 @@ let
         cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
         configureArgs = "--disable-benchmarks";
       }
-    else # ghc98 and above 
+    else if lib.hasInfix "ghc98" ghc then
       {
         rev = "2.5.0.0";
         sha256 = "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=";
-        cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
         configureArgs = "--disable-benchmarks";
-      };
+      }
+    else
+      lib.trace
+        ''
+          Unsupported GHC version ${ghc}, defaulting to ghc810 for haskell-language-server
+        ''
+        {
+          rev = "855a88238279b795634fa6144a4c0e8acc7e9644"; # 1.8.0.0
+          sha256 = "sha256-El5wZDn0br/My7cxstRzUyO7VUf1q5V44T55NEQONnI=";
+          cabalProjectLocal = "constraints: stylish-haskell==0.13.0.0, hlint==3.2.8";
+        };
 
 in
 
@@ -57,7 +66,7 @@ pkgs.haskell-nix.cabalProject' {
     inherit (config) rev sha256;
   };
 
-  compiler-nix-name = config.compiler-nix-name or ghc;
+  compiler-nix-name = ghc;
 
   sha256map = {
     "https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ="; # editorconfig-checker-disable-line

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -26,12 +26,10 @@ let
       }
     else # ghc98 and above 
       {
-        rev = "2.4.0.0";
-        sha256 = "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=";
+        rev = "2.5.0.0";
+        sha256 = "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=";
         cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
         configureArgs = "--disable-benchmarks";
-        # TODO remove me as soon as we can build hls with ghc98
-        compiler-nix-name = "ghc96";
       };
 
 in

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -24,17 +24,14 @@ let
         cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
         configureArgs = "--disable-benchmarks";
       }
-    else if lib.hasInfix "ghc98" ghc then
+    else # ghc98 and above 
       {
         rev = "2.4.0.0";
         sha256 = "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=";
         cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
-      }
-    else
-      {
-        rev = "2.4.0.0";
-        sha256 = "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=";
-        cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
+        configureArgs = "--disable-benchmarks";
+        # TODO remove me as soon as we can build hls with ghc98
+        compiler-nix-name = "ghc96";
       };
 
 in
@@ -62,7 +59,7 @@ pkgs.haskell-nix.cabalProject' {
     inherit (config) rev sha256;
   };
 
-  compiler-nix-name = ghc;
+  compiler-nix-name = config.compiler-nix-name or ghc;
 
   sha256map = {
     "https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ="; # editorconfig-checker-disable-line


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for additional GHC versions in development environments.
  - Introduced a new search function to select the appropriate Haskell Language Server tools.

- **Refactor**
  - Improved the logic for fetching Haskell Language Server components.

- **Chores**
  - Updated Nix configurations for Haskell Language Server and associated tools with new revisions and hashes.

- **Documentation**
  - Specified a new `index-state` for `fourmolu` to ensure consistent formatting across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->