### PR TITLE
Bump HLS versions for 9.6 and 9.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -952,11 +952,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1703636672,
-        "narHash": "sha256-QVADvglA1x9WpQFij73VvdvnqquCUCNBM0BOFHXQz0Y=",
+        "lastModified": 1709166121,
+        "narHash": "sha256-HbYr9SdpKOl1J32BPsB2mN9qQRI6cuYpBsHpRzkBllc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6a9040a7f72c7e629b286a461cf856d987c163ba",
+        "rev": "5cf73b08296632dea6a184da407999950e06613d",
         "type": "github"
       },
       "original": {

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -21,15 +21,16 @@ let
       }
     else if lib.hasInfix "ghc96" ghc then
       {
-        rev = "2.4.0.0";
-        sha256 = "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=";
-        cabalProjectLocal = "constraints: stylish-haskell==0.14.5.0, hlint==3.6.1";
+        rev = "2.7.0.0";
+        sha256 = "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=";
+        cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
         configureArgs = "--disable-benchmarks";
       }
     else if lib.hasInfix "ghc98" ghc then
       {
-        rev = "2.5.0.0";
-        sha256 = "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=";
+        rev = "2.7.0.0";
+        sha256 = "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=";
+        cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
         configureArgs = "--disable-benchmarks";
       }
     else


### PR DESCRIPTION
This is needed to support new minor versions of 9.8. Also they were just quite old.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `stylish-haskell` and `hlint` versions in the Haskell language server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->