### PR TITLE
Update mkReadTheDocsSite.nix to not filter JSON files out.

### DIFF
--- a/src/core/mkReadTheDocsSite.nix
+++ b/src/core/mkReadTheDocsSite.nix
@@ -16,7 +16,7 @@ let
 
     src = lib.sourceFilesBySuffices
       (user-inputs.self + "/${readTheDocs.siteFolder}")
-      [ ".py" ".rst" ".md" ".hs" ".png" ".svg" ".bib" ".csv" ".css" ".html" ".txt" ];
+      [ ".py" ".rst" ".md" ".hs" ".png" ".svg" ".bib" ".csv" ".css" ".html" ".txt" ".json" ];
 
     buildInputs = [
       readTheDocs.sphinxToolchain


### PR DESCRIPTION
In the Plutus RTD site we include CIP-57 blueprints which are JSON Schema files and have `.json` extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the source file recognition by including `.json` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->