### PR TITLE
Fix CHaP input map in template

### DIFF
--- a/templates/haskell/cabal.project
+++ b/templates/haskell/cabal.project
@@ -1,0 +1,10 @@
+repository cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee

--- a/templates/haskell/nix/project.nix
+++ b/templates/haskell/nix/project.nix
@@ -14,7 +14,7 @@ let
       shell.withHoogle = false;
 
       inputMap = {
-        "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.iogx.inputs.CHaP;
+        "https://chap.intersectmbo.org/" = inputs.iogx.inputs.CHaP;
       };
 
       name = "my-project";
@@ -22,9 +22,9 @@ let
       compiler-nix-name = lib.mkDefault "ghc96";
 
       # flake.variants.profiled = {
-      #   modules = [{ 
-      #     enableProfiling = true; 
-      #     enableLibraryProfiling = true; 
+      #   modules = [{
+      #     enableProfiling = true;
+      #     enableLibraryProfiling = true;
       #   }];
       # };
 
@@ -57,9 +57,9 @@ let
 
     shellArgs = repoRoot.nix.shell;
 
-    # includeMingwW64HydraJobs = false; 
+    # includeMingwW64HydraJobs = false;
 
-    # includeProfiledHydraJobs = false; 
+    # includeProfiledHydraJobs = false;
 
     # readTheDocs = {
     #   enable = false;


### PR DESCRIPTION
Fixes the following error when generating a template:

```
kolam@desjardins ~/g/cardano-dapp-template [1]> nix develop
error: builder for '/nix/store/z4xdyiljn34ri7cfhwmw4lm35jllhl80-cardano-haskell-packages.drv' failed with exit code 1;
       last 8 log lines:
       > Warning: Caught exception during _mirrors lookup:res_query: does not exist (No
       > such file or directory)
       > Warning: No mirrors found for https://chap.intersectmbo.org/
       > dieVerbatim: user error (Error: cabal:
       > '/nix/store/6g6s5cqbvk1nw2y2c8lpbn95sk0w24f9-curl-8.2.1-bin/bin/curl' exited
       > with an error:
       > curl: (6) Could not resolve host: chap.intersectmbo.org
       > )
       For full logs, run 'nix log /nix/store/z4xdyiljn34ri7cfhwmw4lm35jllhl80-cardano-haskell-packages.drv'.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated URLs for dependencies and adjusted compiler settings in the Haskell project configuration.
	- Added a new repository with secure URLs and root keys for verification in the `cabal.project` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->