### PR TITLE
Restore templates-outputs in top-level flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,16 +77,19 @@
 
       mkTemplateOutputs = system:
         let
-          vanilla = import inputs.flake-compat { src = ./templates/vanilla; };
-          haskell = import inputs.flake-compat { src = ./templates/haskell; };
+          vanilla = (import inputs.flake-compat { src = ./templates/vanilla; }).defaultNix;
+          haskell = (import inputs.flake-compat { src = ./templates/haskell; }).defaultNix;
         in
         {
-          vanilla.devShells = vanilla.defaultNix.devShells.${system};
+          vanilla = {
+            devShells = vanilla.devShells.${system};
+          };
+
           haskell = {
-            devShells = haskell.defaultNix.devShells.${system};
-            packages = haskell.defaultNix.packages.${system};
-            checks = haskell.defaultNix.checks.${system};
-            hydraJobs = haskell.defaultNix.hydraJobs.${system};
+            devShells = haskell.devShells.${system};
+            packages = haskell.packages.${system};
+            checks = haskell.checks.${system};
+            hydraJobs = haskell.hydraJobs.${system};
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,17 @@
         };
       };
 
+      templates-outputs =
+        let getLocalFlake = path: builtins.getFlake (builtins.toPath path); in
+        {
+          vanilla = {
+            inherit (getLocalFlake ./templates/vanilla) devShells;
+          };
+          haskell = {
+            inherit (getLocalFlake ./templates/haskell) devShells packages checks hydraJobs;
+          };
+        };
+
     in
 
     mkFlake rec {
@@ -126,6 +137,7 @@
           ghc96-shell = mkTestShell lib "ghc96";
           ghc98-shell = mkTestShell lib "ghc98";
           rendered-iogx-api-reference = repoRoot.src.core.mkRenderedIogxApiReference;
+          templates = templates-outputs;
           devShells.default = inputs.self.devShells.default;
           required = lib.iogx.mkHydraRequiredJob { };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -82,10 +82,12 @@
         in
         {
           vanilla.devShells = vanilla.defaultNix.devShells.${system};
-          haskell.devShells = haskell.defaultNix.devShells.${system};
-          haskell.packages = haskell.defaultNix.packages.${system};
-          haskell.checks = vanilla.defaultNix.checks.${system};
-          haskell.hydraJobs = vanilla.defaultNix.hydraJobs.${system};
+          haskell = {
+            devShells = haskell.defaultNix.devShells.${system};
+            packages = haskell.defaultNix.packages.${system};
+            checks = haskell.defaultNix.checks.${system};
+            hydraJobs = haskell.defaultNix.hydraJobs.${system};
+          };
         };
 
     in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced new templates for `vanilla` and `haskell` in the application setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->