### PR TITLE
Bump HLS 2.7 -> 2.8

### DIFF
--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -21,15 +21,15 @@ let
       }
     else if lib.hasInfix "ghc96" ghc then
       {
-        rev = "2.7.0.0";
-        sha256 = "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=";
+        rev = "2.8.0.0";
+        sha256 = "sha256-00000000000000000000000000000000000000000000";
         cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
         configureArgs = "--disable-benchmarks";
       }
     else if lib.hasInfix "ghc98" ghc then
       {
-        rev = "2.7.0.0";
-        sha256 = "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=";
+        rev = "2.8.0.0";
+        sha256 = "sha256-00000000000000000000000000000000000000000000";
         cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
         configureArgs = "--disable-benchmarks";
       }

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -22,14 +22,14 @@ let
     else if lib.hasInfix "ghc96" ghc then
       {
         rev = "2.8.0.0";
-        sha256 = "sha256-00000000000000000000000000000000000000000000";
+        sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
         cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
         configureArgs = "--disable-benchmarks";
       }
     else if lib.hasInfix "ghc98" ghc then
       {
         rev = "2.8.0.0";
-        sha256 = "sha256-00000000000000000000000000000000000000000000";
+        sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
         cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
         configureArgs = "--disable-benchmarks";
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Upgraded Haskell Language Server from version 2.7.0.0 to 2.8.0.0 for better compatibility with newer GHC versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->