### PR TITLE
Bump nixpkgs-fmt 1.1.0 -> 1.3.0

### DIFF
--- a/src/ext/nixpkgs-fmt.nix
+++ b/src/ext/nixpkgs-fmt.nix
@@ -10,10 +10,10 @@ pkgs.rustPlatform.buildRustPackage rec {
     owner = "nix-community";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fb2mm1y2qb3imc48g2ad3rdbjlj326cggrc4hvdc0fb41vxinpp";
+    sha256 = "sha256-6Ut4/ix915EoaPCewoG3KhKBA+OaggpDqnx2nvKxEpQ=";
   };
 
-  cargoSha256 = "1lsw6dwkjdwdqcx7gjsg2ndi4r79m8qyxgx7yz3al0iscwm7i645";
+  cargoSha256 = "sha256-yIwCBm46sgrpTt45uCyyS7M6V0ReGUXVu7tyrjdNqeQ=";
 
   meta = with lib; {
     description = "Nix code formatter for nixpkgs";

--- a/src/ext/nixpkgs-fmt.nix
+++ b/src/ext/nixpkgs-fmt.nix
@@ -4,8 +4,7 @@ pkgs.rustPlatform.buildRustPackage rec {
 
   pname = "nixpkgs-fmt";
 
-  # nixpkgs-fmt 1.2.0 breaks indentation of code examples in comments
-  version = "1.1.0";
+  version = "1.3.0";
 
   src = pkgs.fetchFromGitHub {
     owner = "nix-community";

--- a/src/options/mkGitRevOverlay.nix
+++ b/src/options/mkGitRevOverlay.nix
@@ -1,2 +1,2 @@
 iogx-inputs:
-{}
+{ }

--- a/src/options/mkHydraRequiredJob.nix
+++ b/src/options/mkHydraRequiredJob.nix
@@ -1,2 +1,2 @@
 iogx-inputs:
-{}
+{ }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `nixpkgs-fmt` version from 1.1.0 to 1.3.0 for improved formatting and stability.
  - Minor formatting adjustments in configuration files for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->