### PR TITLE
Update flake manually and fourmolu

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1730295876,
-        "narHash": "sha256-ijnHTQ6eKIQ9FpEqDKt6c7vuFYN8aOBDhonp67utx2s=",
+        "lastModified": 1733132525,
+        "narHash": "sha256-qD1Mo1MUxaNJnJCAQHMo5cfgMoHv6nb7nTS087CPkio=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "25591f43ab943d5a070db5e8a2b9ff3a499d4d92",
+        "rev": "4bd42413109a7935695346cabdf4f528f0e4f36f",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -206,11 +206,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -278,11 +278,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1730680170,
-        "narHash": "sha256-CUPGIJ4PMrGKVC30bZfCrlzvTvlAjvz2bQ091DKqNNk=",
+        "lastModified": 1733099475,
+        "narHash": "sha256-YVGmAXFmh0FkPSrLt33kVAgv79RaffNZOkEvO7Ru1q8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3f9db9843a52f45de2e9884838de31fe7c526c75",
+        "rev": "8b4a3467f2fea817bef20ed424dece1fb1323d4d",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1730681472,
-        "narHash": "sha256-Dj7VqPI2Y5sGNQoe/TB6AVjzU5GcHswD7HA0QtxAzhQ=",
+        "lastModified": 1733100689,
+        "narHash": "sha256-xqwYZyeJycNjZbCAW7S810ZErnwJljeLgs2rbpGa0YI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ff2349914ccdc5f2ec04bd3e96967da142176e9f",
+        "rev": "a611dfa0dfba7fb72790a186a59312e8598464c9",
         "type": "github"
       },
       "original": {
@@ -565,11 +565,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1730297014,
-        "narHash": "sha256-n3f1iAmltKnorHWx7FrdbGIF/FmEG8SsZshS16vnpz0=",
+        "lastModified": 1732287300,
+        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "d407eedd4995e88d08e83ef75844a8a9c2e29b36",
+        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1726447378,
-        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
+        "lastModified": 1729242558,
+        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
+        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
         "type": "github"
       },
       "original": {
@@ -829,11 +829,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -845,11 +845,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1726583932,
-        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "lastModified": 1729980323,
+        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
         "type": "github"
       },
       "original": {
@@ -876,11 +876,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
@@ -915,11 +915,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -1000,11 +1000,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1730679100,
-        "narHash": "sha256-iPXuh2rG9wd01CyZX85MdCDuZKt/+sorJ/q/8EcQdvc=",
+        "lastModified": 1733012053,
+        "narHash": "sha256-tGP50DXm44W8fyhbPE9RqJ/vMz8haA/UEuMikHUK6rI=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "e78d11489de1835924f10352dc212c8df0c5e640",
+        "rev": "7f5618355d29e4b4d3eb0d927fba63055a4a4856",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1732722421,
-        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -278,11 +278,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1733099475,
-        "narHash": "sha256-YVGmAXFmh0FkPSrLt33kVAgv79RaffNZOkEvO7Ru1q8=",
+        "lastModified": 1733358616,
+        "narHash": "sha256-96x1H0cfIX2iMx3FkmFDoXohBCBVUJt5DH3457xAXVM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "8b4a3467f2fea817bef20ed424dece1fb1323d4d",
+        "rev": "bb0ec3418c4593dd79ed2f5423f8fddd1db726ae",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1733100689,
-        "narHash": "sha256-xqwYZyeJycNjZbCAW7S810ZErnwJljeLgs2rbpGa0YI=",
+        "lastModified": 1733359919,
+        "narHash": "sha256-5LI4bETTK7fi+nr5nfSEQEBhx8+ZtKHFrH9oEqlj18E=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a611dfa0dfba7fb72790a186a59312e8598464c9",
+        "rev": "6bfaa3f488a3aa20153d9278a311120a9036459a",
         "type": "github"
       },
       "original": {
@@ -915,11 +915,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -1000,11 +1000,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1733012053,
-        "narHash": "sha256-tGP50DXm44W8fyhbPE9RqJ/vMz8haA/UEuMikHUK6rI=",
+        "lastModified": 1733357539,
+        "narHash": "sha256-r5B5lCFZC1a/V+banTIYzjOVlP2lIuLrhnC1FnCMAl0=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "7f5618355d29e4b4d3eb0d927fba63055a4a4856",
+        "rev": "d6b9beeb93d98ea98b6ad32f36768cad48177e89",
         "type": "github"
       },
       "original": {

--- a/src/ext/fourmolu.nix
+++ b/src/ext/fourmolu.nix
@@ -7,7 +7,7 @@ let
   project = pkgs.haskell-nix.hackage-project {
     name = "fourmolu";
     version = "0.16.2.0";
-    compiler-nix-name = "ghc983";
+    compiler-nix-name = "ghc982";
 
     modules =
       [{ packages.fourmolu.components.exes.fourmolu.dontStrip = false; }];

--- a/src/ext/fourmolu.nix
+++ b/src/ext/fourmolu.nix
@@ -7,7 +7,7 @@ let
   project = pkgs.haskell-nix.hackage-project {
     name = "fourmolu";
     version = "0.16.2.0";
-    compiler-nix-name = "ghc982";
+    compiler-nix-name = "ghc983";
 
     modules =
       [{ packages.fourmolu.components.exes.fourmolu.dontStrip = false; }];

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -32,9 +32,9 @@ let
     hls-fallback = repoRoot.src.ext.haskell-language-server-project "ghc98";
   } else
     lib.trace ''
-      Unsupported GHC version ${ghc}, defaulting to ghc98 and haskell-language-server v2.8.0.0
+      Unsupported GHC version ${ghc}, defaulting to ghc983 and haskell-language-server v2.8.0.0
     '' {
-      ghc = "ghc98";
+      ghc = "ghc983";
       rev = "2.8.0.0";
       sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
       cabalProjectLocal =

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -19,7 +19,7 @@ let
     sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
     cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
     configureArgs = "--disable-benchmarks";
-  } else if lib.hasInfix "ghc98" ghc then {
+  } else if lib.hasInfix "ghc982" ghc then {
     rev = "2.8.0.0";
     sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
     cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
@@ -32,9 +32,9 @@ let
     hls-fallback = repoRoot.src.ext.haskell-language-server-project "ghc98";
   } else
     lib.trace ''
-      Unsupported GHC version ${ghc}, defaulting to ghc983 and haskell-language-server v2.8.0.0
+      Unsupported GHC version ${ghc}, defaulting to ghc982 and haskell-language-server v2.8.0.0
     '' {
-      ghc = "ghc983";
+      ghc = "ghc982";
       rev = "2.8.0.0";
       sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
       cabalProjectLocal =

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -19,9 +19,9 @@ let
     sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
     cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
     configureArgs = "--disable-benchmarks";
-  } else if lib.hasInfix "ghc982"
-  ghc then # TODO replace with ghc98 when HLS supports ghc983
-  {
+  }
+  # TODO replace with ghc98 when HLS supports ghc983
+  else if lib.hasInfix "ghc982" ghc then {
     rev = "2.8.0.0";
     sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
     cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";

--- a/src/ext/haskell-language-server-project.nix
+++ b/src/ext/haskell-language-server-project.nix
@@ -19,7 +19,9 @@ let
     sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
     cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
     configureArgs = "--disable-benchmarks";
-  } else if lib.hasInfix "ghc982" ghc then {
+  } else if lib.hasInfix "ghc982"
+  ghc then # TODO replace with ghc98 when HLS supports ghc983
+  {
     rev = "2.8.0.0";
     sha256 = "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=";
     cabalProjectLocal = "constraints: stylish-haskell ^>= 0.14, hlint ^>= 3.8";
@@ -64,7 +66,7 @@ let
       inherit (config) rev sha256;
     };
 
-    compiler-nix-name = ghc;
+    compiler-nix-name = config.ghc or ghc;
 
     sha256map = {
       "https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated configuration for GHC version handling in the Haskell Language Server.
	- Enhanced fallback mechanism for unsupported GHC versions to reflect `ghc982`.

- **Bug Fixes**
	- Consolidated error messages and configurations for GHC versions to ensure consistency.

- **Chores**
	- Added comments for future updates regarding GHC version support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->