### PR TITLE
Adapt to more recent haskell.nix

### DIFF
--- a/src/core/mkShellWith.nix
+++ b/src/core/mkShellWith.nix
@@ -34,7 +34,7 @@ let
   };
 
   ghc = if shell.tools.haskellCompilerVersion == null then
-    "ghc8107"
+    "ghc96"
   else
     shell.tools.haskellCompilerVersion;
 

--- a/src/ext/cabal-fmt.nix
+++ b/src/ext/cabal-fmt.nix
@@ -7,7 +7,7 @@ let
 
     version = "0.1.12";
 
-    compiler-nix-name = "ghc92";
+    compiler-nix-name = "ghc96";
 
     # Cabal is a lib library, so haskell.nix would normally use the one coming
     # from the compiler-nix-name (currently 3.2). However cabal-fmt depends on

--- a/src/ext/fourmolu.nix
+++ b/src/ext/fourmolu.nix
@@ -7,7 +7,7 @@ let
   project = pkgs.haskell-nix.hackage-project {
     name = "fourmolu";
     version = "0.16.2.0";
-    compiler-nix-name = "ghc982";
+    compiler-nix-name = "ghc98";
 
     modules =
       [{ packages.fourmolu.components.exes.fourmolu.dontStrip = false; }];


### PR DESCRIPTION
Move from 9.2 to 9.6.

haskell.nix will drop support ghc < 9.6 in the future. And currently 9.2. doesn't even build on Darwin, as it requires 8.10 to bootstrap and that's broken, and will be removed from haskell.nix in the not too distant future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the Haskell compiler version for the code formatting tool.
  - Updated the compiler version used in another formatting project.
  - Modernized the development shell environment with the new Haskell compiler version for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->