### PR TITLE
Fix update-flake-lock.yaml template

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -24,9 +24,6 @@ jobs:
           cd "$GITHUB_WORKSPACE/templates/haskell"
           nix flake update --accept-flake-config
 
-          cd "$GITHUB_WORKSPACE/templates/vanilla"
-          nix flake update --accept-flake-config
-
           cd "$GITHUB_WORKSPACE"
           git add .
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated CI workflow for dependency lockfile maintenance: the Vanilla template is no longer included in automated flake.lock updates, while the Haskell template continues to be updated automatically.
  * Retained existing steps for repository checkout, Nix setup, commit, pull request creation, and auto-merge behavior.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->