### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs: inputs.flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (system: 
+  outputs = inputs: inputs.flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] (system: 
     let
       pkgs = inputs.nixpkgs.legacyPackages.${system};
     in 

--- a/templates/haskell/nix/outputs.nix
+++ b/templates/haskell/nix/outputs.nix
@@ -35,7 +35,6 @@ let
 
   hydraJobsPerSystem = {
     "x86_64-linux" = defaultHydraJobs; 
-    "x86_64-darwin" = defaultHydraJobs;
     "aarch64-linux" = defaultHydraJobs; 
     "aarch64-darwin" = defaultHydraJobs;
   };

--- a/templates/haskell/nix/outputs.nix
+++ b/templates/haskell/nix/outputs.nix
@@ -35,6 +35,7 @@ let
 
   hydraJobsPerSystem = {
     "x86_64-linux" = defaultHydraJobs; 
+    "x86_64-darwin" = {}; 
     "aarch64-linux" = defaultHydraJobs; 
     "aarch64-darwin" = defaultHydraJobs;
   };


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed support for Intel macOS (x86_64-darwin). Development shells, packaged builds, and continuous-integration job artifacts will no longer be produced for Intel-based Macs, while ARM macOS and Linux outputs continue to be generated. Users on Intel Macs should expect reduced platform coverage for prebuilt dev environments and CI results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/input-output-hk/iogx/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->